### PR TITLE
Make Clever API version configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Example: In `config/initializers/omniauth.rb`, do:
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :clever, ENV['CLEVER_CLIENT_ID'], ENV['CLEVER_CLIENT_SECRET'],
-           api_version: 'v2.1' # Optional – defaults to 'v3.0'
+           api_version: 'v3.0'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Example: In `config/initializers/omniauth.rb`, do:
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :clever, ENV['CLEVER_CLIENT_ID'], ENV['CLEVER_CLIENT_SECRET']
+  provider :clever, ENV['CLEVER_CLIENT_ID'], ENV['CLEVER_CLIENT_SECRET'],
+           api_version: 'v2.1' # Optional – defaults to 'v3.0'
 end
 ```
 

--- a/lib/omniauth/clever/version.rb
+++ b/lib/omniauth/clever/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Clever
-    VERSION = "1.2.3"
+    VERSION = "1.3.0"
   end
 end

--- a/lib/omniauth/strategies/clever.rb
+++ b/lib/omniauth/strategies/clever.rb
@@ -9,7 +9,7 @@ module OmniAuth
       # login, a state parameter is not relevant nor sent.
 
       option :name, "clever"
-      option :api_version, 'v3.0'
+      option :api_version, 'v2.1'
       option :client_options, {
         :site          => 'https://api.clever.com',
         :authorize_url => 'https://clever.com/oauth/authorize',
@@ -56,10 +56,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get(
-          '/me',
-          { 'Accept-Version' => options.api_version }
-        ).parsed
+        @raw_info ||= access_token.get("/#{options.api_version}/me").parsed
       end
 
       # Fix unknown redirect uri bug by NOT appending the query string to the callback url.

--- a/lib/omniauth/strategies/clever.rb
+++ b/lib/omniauth/strategies/clever.rb
@@ -9,6 +9,7 @@ module OmniAuth
       # login, a state parameter is not relevant nor sent.
 
       option :name, "clever"
+      option :api_version, 'v3.0'
       option :client_options, {
         :site          => 'https://api.clever.com',
         :authorize_url => 'https://clever.com/oauth/authorize',
@@ -55,7 +56,10 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('/me').parsed
+        @raw_info ||= access_token.get(
+          '/me',
+          { 'Accept-Version' => options.api_version }
+        ).parsed
       end
 
       # Fix unknown redirect uri bug by NOT appending the query string to the callback url.

--- a/lib/omniauth/strategies/clever.rb
+++ b/lib/omniauth/strategies/clever.rb
@@ -9,7 +9,7 @@ module OmniAuth
       # login, a state parameter is not relevant nor sent.
 
       option :name, "clever"
-      option :api_version, 'v2.1'
+      option :api_version, 'v3.0'
       option :client_options, {
         :site          => 'https://api.clever.com',
         :authorize_url => 'https://clever.com/oauth/authorize',


### PR DESCRIPTION
Related to https://github.com/ClassTagInc/classtag_web/pull/17376
By default, the /me endpoint in Clever's OAuth flow uses API version v2.1, which is expected to be deprecated in the near future. While Clever may eventually auto-upgrade this to v3.0, the structure and response format = particularly in fields like links, will change (I suppose).

To avoid surprises during that transition and ensure we explicitly control which version we consume, this PR adds support for setting the Accept-Version header via a new api_version option (defaulting to v3.0). This makes the strategy safer and more future-proof while preserving backward compatibility.

Example of legacy (v2.1):

```
links: [
  { rel: "self", uri: "/me" },
  { rel: "canonical", uri: "/v2.1/teachers/:id..." },
  { rel: "district", uri: "/v2.1/districts/:id..." }
]
```


Example (v3.0):

```
links: [
  { rel: "self", uri: "/me" },
  { rel: "canonical", uri: "/v3.0/users/:id..." },
  { rel: "district", uri: "/v3.0/districts/:id..." }
]
```